### PR TITLE
show alert when clicking fill test account info 

### DIFF
--- a/CloudDoor/SettingsView.swift
+++ b/CloudDoor/SettingsView.swift
@@ -11,11 +11,13 @@ struct SettingsView: View {
     @State var alertTitle = ""
     @State var alertMessage = ""
     @State var showAlert = false
-    
+    @State var showAlertWithCancel = false
+
     @State private var username: String
     @State private var password: String
     @State private var hostname: String
     
+    let testingHost = "https://cloud-door-mock.test.dejanlevec.com"
     let productionHost = "https://api.doorcloud.com"
     let configuration = Configuration()
     
@@ -24,6 +26,12 @@ struct SettingsView: View {
         self.username = values.username
         self.password = values.password
         self.hostname = values.hostname == "" ? self.productionHost : values.hostname
+    }
+
+    func fillTestAccountInfo() {
+        self.username = "user@example.com"
+        self.password = "password"
+        self.hostname = testingHost
     }
 
     var body: some View {
@@ -80,15 +88,25 @@ struct SettingsView: View {
                         self.hostname = self.productionHost
                     }
                     Button("Reset values to test configuration") {
-                        self.username = "user@example.com"
-                        self.password = "password"
-                        self.hostname = "https://cloud-door-mock.test.dejanlevec.com"
+                        alertTitle = "Warning"
+                        alertMessage = "You are about to replace existing account info with test account info."
+                        showAlertWithCancel = true
                     }
                 }
             }
             .navigationTitle("Settings")
-            .alert(isPresented: $showAlert, content: {
-                Alert(title: Text(self.alertTitle), message: Text(self.alertMessage), dismissButton: .default(Text("OK")))
+            .alert(alertTitle, isPresented: $showAlertWithCancel, actions: {
+                Button("Cancel", role: .cancel) {}
+                Button("OK", role: .destructive) {
+                    fillTestAccountInfo()
+                }
+            }, message: {
+                Text(alertMessage)
+            })
+            .alert(alertTitle, isPresented: $showAlert, actions: {
+                Button("OK", role: .cancel) { }
+            }, message: {
+                Text(alertMessage)
             })
         }
     }


### PR DESCRIPTION
**show alert when clicking fill test account info**

To prevent the user from overwriting his account info by accidentally
clicking the Fill in test user account info button we first show an
alert with a warning message.

<img width="335" alt="Screenshot 2025-01-09 at 20 54 20" src="https://github.com/user-attachments/assets/342e5e86-62c5-4d03-9233-81fbaa91f2af" /><br>

**add environment picker**

- remove the hostname textfield
- add a picker to select between production and testing environments
- remove set hostname to production button

<img width="544" alt="Screenshot 2025-01-09 at 20 54 03" src="https://github.com/user-attachments/assets/1f15bfda-9e11-4aa5-bf95-deb3db99efac" />